### PR TITLE
Fix comment on reinstallation

### DIFF
--- a/python/saleae/automation/__init__.py
+++ b/python/saleae/automation/__init__.py
@@ -4,9 +4,9 @@ except Exception as exc:
     import sys
     sys.stderr.write('''There was an error that occurred while importing grpc/pb modules.
 This can be caused by pb files that were generated using an incompatible version of protobuf.
-You can regenerate these files by reinstalling logic2-automaation:
+You can regenerate these files by reinstalling logic2-automation:
 
-     pip --force-reinstall logic2-automation
+     pip install logic2-automation --force-reinstall
 
  ''')
     raise exc from None


### PR DESCRIPTION
`pip` first takes in the command (i.e., `install`), then options, so `--force-reinstall` should be at the end. Also, `automation` should have 2 `a`s, not 3.