### PR TITLE
add a test that verifies adding an invalid analyzer generates an error.

### DIFF
--- a/python/tests/analyzer_test.py
+++ b/python/tests/analyzer_test.py
@@ -5,6 +5,20 @@ import time
 
 import saleae.automation
 
+def test_add_nonexistent_analyzer(manager: saleae.automation.Manager, asset_path: str):
+    """
+    PRO-1182: Test that adding a non-existent analyzer returns InvalidRequestError.
+    """
+    path = os.path.join(asset_path, 'small_spi_capture.sal')
+
+    with manager.load_capture(path) as cap:
+        try:
+            cap.add_analyzer('NonExistentAnalyzer', label='Test', settings={})
+            assert False, "Expected InvalidRequestError for non-existent analyzer"
+        except saleae.automation.InvalidRequestError:
+            pass
+
+
 def test_add_analyzer(manager: saleae.automation.Manager, asset_path: str):
     path = os.path.join(asset_path, 'small_spi_capture.sal')
     


### PR DESCRIPTION
Unclear if this test actually adds value.

Logic 2 always supported returning an error when trying to create an analyzer that didn't exist, but previously the error message text was not useful for understanding the root problem.

That is getting fixed, and this originally verified that the correct error text was shown.

However that was removed to avoid depending on the error display text, but since we didn't add a new error type specifically for this error, this test no longer actually verifies the correct error message was displayed.

It might still be helpful to directly test this error case though, since it could be a common error for folks trying to setup custom analyzers in CI environments, since the custom analyzer path does need to be configured correctly.